### PR TITLE
Transfer session in request / response

### DIFF
--- a/public/javascripts/terminal.js
+++ b/public/javascripts/terminal.js
@@ -1,6 +1,8 @@
 var historyValues = [];
 var historyCursor = 0;
 
+var sessionId = null;
+
 function submitCommand(text, dontClearInput) {
   historyValues.push(text);
   historyCursor = historyValues.length;
@@ -12,7 +14,10 @@ function submitCommand(text, dontClearInput) {
     $("#input").val("");
   }
 
-  jQuery.getJSON("eval", { command: text }, function (data) {
+  jQuery.getJSON("eval", { command: text, sessionId: sessionId }, function (data) {
+    if(data.sessionId !== undefined && data.sessionId !== sessionId) {
+      sessionId = data.sessionId
+    }
     if (data.response !== undefined) {
       append(JSON.stringify(data.response), "response");
     } else if (data.error !== undefined) {

--- a/try-redis.rb
+++ b/try-redis.rb
@@ -2,6 +2,7 @@
 
 require "shellwords"
 require "logger"
+require "json"
 
 module NamespaceTools
   def namespace_input(ns, command, *args)
@@ -130,7 +131,16 @@ class TryRedis < Sinatra::Base
 
   get("/")          { haml :index }
   get("/style.css") { sass :style }
-  get("/eval")      { evaluate_redis(params["command"]).to_json }
+  
+  get("/eval") do
+    if !params["sessionId"].nil? and params["sessionId"] != "null"      
+      params["sessionId"].each do |k,v|
+        session[k] = v
+        env["rack.session"][k] = v
+      end
+    end
+    evaluate_redis(params["command"]).merge(:sessionId => env["rack.session"]).to_json
+  end
 
   include NamespaceTools
 


### PR DESCRIPTION
fixes #7

The downside of this patch is obvious: The session is transferred through the querystring / response body.
This lowers security (which shouldn't be too much of a problem for this, though).
Transferring the session in the querystring limits it to the maximum URL length (8KB?).
The session is small enough to not suffer from that.
